### PR TITLE
Refactor model constructors to remove logger and context

### DIFF
--- a/pkg/models/licenses_test.go
+++ b/pkg/models/licenses_test.go
@@ -42,11 +42,11 @@ func TestLicensesSearch(t *testing.T) {
 
 	q := database.NewDBSelectContext(s, db, nil, false)
 
-	licenseModel := NewLicenseModel(ctx, s, q, db)
+	licenseModel := NewLicenseModel(q, db)
 
 	var name = "MIT"
 	fmt.Printf("Searching for license: %v\n", name)
-	license, err := licenseModel.GetLicenseByName(name)
+	license, err := licenseModel.GetLicenseByName(ctx, name)
 	if err != nil {
 		t.Errorf("licenses.GetLicenseByName() error = %v", err)
 	}
@@ -57,7 +57,7 @@ func TestLicensesSearch(t *testing.T) {
 
 	name = ""
 	fmt.Printf("Searching for license: %v\n", name)
-	license, err = licenseModel.GetLicenseByName(name)
+	license, err = licenseModel.GetLicenseByName(ctx, name)
 	if err != nil {
 		t.Errorf("licenses.GetLicenseByName() error = %v", err)
 	}
@@ -68,7 +68,7 @@ func TestLicensesSearch(t *testing.T) {
 
 	name = "Unknown License"
 	fmt.Printf("Searching for license: %v\n", name)
-	license, err = licenseModel.GetLicenseByName(name)
+	license, err = licenseModel.GetLicenseByName(ctx, name)
 	if err != nil {
 		t.Errorf("licenses.GetLicenseByName() error = %v", err)
 	}
@@ -92,11 +92,11 @@ func TestLicensesSearchId(t *testing.T) {
 
 	q := database.NewDBSelectContext(s, db, nil, false)
 
-	licenseModel := NewLicenseModel(ctx, s, q, db)
+	licenseModel := NewLicenseModel(q, db)
 
 	name := "MIT"
 	fmt.Printf("Searching for license: %v\n", name)
-	license, err := licenseModel.GetLicenseByName(name)
+	license, err := licenseModel.GetLicenseByName(ctx, name)
 	if err != nil {
 		t.Errorf("licenseModel.GetLicenseByName() error = %v", err)
 	}
@@ -107,7 +107,7 @@ func TestLicensesSearchId(t *testing.T) {
 
 	id := license.ID
 	fmt.Printf("Searching for license by id: %v\n", id)
-	license, err = licenseModel.GetLicenseByID(id)
+	license, err = licenseModel.GetLicenseByID(ctx, id)
 	if err != nil {
 		t.Errorf("licenses.GetLicenseByID() error = %v", err)
 	}
@@ -118,7 +118,7 @@ func TestLicensesSearchId(t *testing.T) {
 
 	id = 109
 	fmt.Printf("Searching for license by id: %v\n", id)
-	license, err = licenseModel.GetLicenseByID(id)
+	license, err = licenseModel.GetLicenseByID(ctx, id)
 	if err != nil {
 		t.Errorf("licenses.GetLicenseByID() error = %v", err)
 	}
@@ -129,7 +129,7 @@ func TestLicensesSearchId(t *testing.T) {
 
 	id = -1
 	fmt.Printf("Searching for license by id: %v\n", id)
-	_, err = licenseModel.GetLicenseByID(id)
+	_, err = licenseModel.GetLicenseByID(ctx, id)
 	if err == nil {
 		t.Errorf("licenses.GetLicenseByID() error = did not get an error")
 	} else {

--- a/pkg/models/mines_test.go
+++ b/pkg/models/mines_test.go
@@ -42,24 +42,24 @@ func TestMines(t *testing.T) {
 	testutils.LoadMockSQLData(t, db, "../../internal/testutils/mock")
 
 	q := database.NewDBSelectContext(s, db, nil, false)
-	mine := NewMineModel(ctx, s, q)
+	mine := NewMineModel(q)
 
 	var purlType = "maven"
-	mineIds, err := mine.GetMineIdsByPurlType(purlType)
+	mineIds, err := mine.GetMineIdsByPurlType(ctx, purlType)
 	if err != nil {
 		t.Errorf("mines.GetMineIdByPurlType() error = %v", err)
 	}
 	fmt.Printf("Mine ID for %v: %v\n", purlType, mineIds)
 
 	purlType = "gem"
-	mineIds, err = mine.GetMineIdsByPurlType(purlType)
+	mineIds, err = mine.GetMineIdsByPurlType(ctx, purlType)
 	if err != nil {
 		t.Errorf("mines.GetMineIdByPurlType() error = %v", err)
 	}
 	fmt.Printf("Mine ID for %v: %v\n", purlType, mineIds)
 
 	purlType = ""
-	mineIds, err = mine.GetMineIdsByPurlType(purlType)
+	mineIds, err = mine.GetMineIdsByPurlType(ctx, purlType)
 	if err != nil {
 		fmt.Printf("Mine ID not found: %v\n", err)
 	} else {
@@ -67,7 +67,7 @@ func TestMines(t *testing.T) {
 	}
 
 	purlType = "NONEXISTENT"
-	mineIds, err = mine.GetMineIdsByPurlType(purlType)
+	mineIds, err = mine.GetMineIdsByPurlType(ctx, purlType)
 	if err != nil {
 		fmt.Printf("Mine ID not found: %v\n", err)
 	} else {
@@ -75,7 +75,7 @@ func TestMines(t *testing.T) {
 	}
 
 	purlType = "npm"
-	mineIds, err = mine.GetMineIdsByPurlType(purlType)
+	mineIds, err = mine.GetMineIdsByPurlType(ctx, purlType)
 	if err != nil {
 		t.Errorf("mines.GetMineIdsByPurlType() error = %v", err)
 	}
@@ -95,10 +95,10 @@ func TestMinesBadSql(t *testing.T) {
 	defer testutils.CloseDB(t, db)
 
 	q := database.NewDBSelectContext(s, db, nil, false)
-	mine := NewMineModel(ctx, s, q)
+	mine := NewMineModel(q)
 
 	purlType := "NONEXISTENT"
-	mineIds, err := mine.GetMineIdsByPurlType(purlType)
+	mineIds, err := mine.GetMineIdsByPurlType(ctx, purlType)
 	if err != nil {
 		fmt.Printf("Mine ID not found: %v\n", err)
 	} else {

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -53,7 +53,7 @@ func NewModels(ctx context.Context, s *zap.SugaredLogger, q *database.DBQueryCon
 	models.Versions = NewVersionModel(ctx, s, q, db)
 	models.Licenses = NewLicenseModel(ctx, s, q, db)
 	models.Mines = NewMineModel(ctx, s, q)
-	models.AllUrls = NewAllURLModel(ctx, s, q)
+	models.AllUrls = NewAllURLModel(q)
 
 	return models
 }

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -51,7 +51,7 @@ func NewModels(ctx context.Context, s *zap.SugaredLogger, q *database.DBQueryCon
 
 	models.Projects = NewProjectModel(ctx, s, q, db)
 	models.Versions = NewVersionModel(ctx, s, q, db)
-	models.Licenses = NewLicenseModel(ctx, s, q, db)
+	models.Licenses = NewLicenseModel(q, db)
 	models.Mines = NewMineModel(ctx, s, q)
 	models.AllUrls = NewAllURLModel(q)
 

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -50,7 +50,7 @@ func NewModels(ctx context.Context, s *zap.SugaredLogger, q *database.DBQueryCon
 	}
 
 	models.Projects = NewProjectModel(q, db)
-	models.Versions = NewVersionModel(ctx, s, q, db)
+	models.Versions = NewVersionModel(q, db)
 	models.Licenses = NewLicenseModel(q, db)
 	models.Mines = NewMineModel(q)
 	models.AllUrls = NewAllURLModel(q)

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -52,7 +52,7 @@ func NewModels(ctx context.Context, s *zap.SugaredLogger, q *database.DBQueryCon
 	models.Projects = NewProjectModel(ctx, s, q, db)
 	models.Versions = NewVersionModel(ctx, s, q, db)
 	models.Licenses = NewLicenseModel(q, db)
-	models.Mines = NewMineModel(ctx, s, q)
+	models.Mines = NewMineModel(q)
 	models.AllUrls = NewAllURLModel(q)
 
 	return models

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -49,7 +49,7 @@ func NewModels(ctx context.Context, s *zap.SugaredLogger, q *database.DBQueryCon
 		db:  db,
 	}
 
-	models.Projects = NewProjectModel(ctx, s, q, db)
+	models.Projects = NewProjectModel(q, db)
 	models.Versions = NewVersionModel(ctx, s, q, db)
 	models.Licenses = NewLicenseModel(q, db)
 	models.Mines = NewMineModel(q)

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -17,20 +17,16 @@
 package models
 
 import (
-	"context"
 	"github.com/jmoiron/sqlx"
 
 	"github.com/scanoss/go-grpc-helper/pkg/grpc/database"
-	"go.uber.org/zap"
 )
 
 // Models provides unified access to all SCANOSS data models.
 // It maintains database connections and provides access to individual model instances.
 type Models struct {
-	ctx context.Context
-	s   *zap.SugaredLogger
-	q   *database.DBQueryContext
-	db  *sqlx.DB
+	q  *database.DBQueryContext
+	db *sqlx.DB
 
 	AllUrls  *AllUrlsModel
 	Projects *ProjectModel
@@ -41,12 +37,10 @@ type Models struct {
 
 // NewModels creates a new instance of the unified SCANOSS models database wrapper.
 // It initializes all individual models and sets up their dependencies.
-func NewModels(ctx context.Context, s *zap.SugaredLogger, q *database.DBQueryContext, db *sqlx.DB) *Models {
+func NewModels(q *database.DBQueryContext, db *sqlx.DB) *Models {
 	models := &Models{
-		ctx: ctx,
-		s:   s,
-		q:   q,
-		db:  db,
+		q:  q,
+		db: db,
 	}
 
 	models.Projects = NewProjectModel(q, db)

--- a/pkg/models/models_test.go
+++ b/pkg/models/models_test.go
@@ -40,7 +40,7 @@ func TestNewDB(t *testing.T) {
 	testutils.LoadMockSQLData(t, db, "../../internal/testutils/mock")
 
 	q := database.NewDBSelectContext(s, db, nil, false)
-	models := NewModels(ctx, s, q, db)
+	models := NewModels(q, db)
 
 	if models.AllUrls == nil {
 		t.Error("NewModels did not initialize AllUrls model")

--- a/pkg/models/projects_test.go
+++ b/pkg/models/projects_test.go
@@ -40,11 +40,11 @@ func TestProjectsSearch(t *testing.T) {
 	testutils.LoadMockSQLData(t, db, "../../internal/testutils/mock")
 	q := database.NewDBSelectContext(s, db, nil, false)
 
-	projectsModel := NewProjectModel(ctx, s, q, db)
+	projectsModel := NewProjectModel(q, db)
 	var purlName = "tablestyle"
 	var purlType = "gem"
 	fmt.Printf("Searching for project list: %v - %v\n", purlName, purlType)
-	projects, err := projectsModel.GetProjectsByPurlName(purlName, purlType)
+	projects, err := projectsModel.GetProjectsByPurlName(ctx, purlName, purlType)
 	if err != nil {
 		t.Errorf("projects.GetProjectsByPurlName() error = %v", err)
 	}
@@ -56,7 +56,7 @@ func TestProjectsSearch(t *testing.T) {
 	purlName = ""
 	purlType = "npm"
 	fmt.Printf("Searching for project list: %v - %v\n", purlName, purlType)
-	_, err = projectsModel.GetProjectsByPurlName(purlName, purlType)
+	_, err = projectsModel.GetProjectsByPurlName(ctx, purlName, purlType)
 	if err == nil {
 		t.Errorf("projects.GetProjectsByPurlName() error = did not get an error")
 	} else {
@@ -65,7 +65,7 @@ func TestProjectsSearch(t *testing.T) {
 	purlName = "tablestyle"
 	purlType = ""
 	fmt.Printf("Searching for project list: %v - %v\n", purlName, purlType)
-	_, err = projectsModel.GetProjectsByPurlName(purlName, purlType)
+	_, err = projectsModel.GetProjectsByPurlName(ctx, purlName, purlType)
 	if err == nil {
 		t.Errorf("projects.GetProjectsByPurlName() error = did not get an error")
 	} else {
@@ -74,7 +74,7 @@ func TestProjectsSearch(t *testing.T) {
 	purlName = "tablestyle"
 	var mineId int32 = 1
 	fmt.Printf("Searching for project: %v - %v\n", purlName, mineId)
-	project, err := projectsModel.GetProjectByPurlName("tablestyle", mineId)
+	project, err := projectsModel.GetProjectByPurlName(ctx, "tablestyle", mineId)
 	if err != nil {
 		t.Errorf("projects.GetProjectByPurlName() error = %+v", err)
 	}
@@ -86,7 +86,7 @@ func TestProjectsSearch(t *testing.T) {
 	purlName = ""
 	mineId = -1
 	fmt.Printf("Searching for project list: %v - %v\n", purlName, purlType)
-	_, err = projectsModel.GetProjectByPurlName(purlName, mineId)
+	_, err = projectsModel.GetProjectByPurlName(ctx, purlName, mineId)
 	if err == nil {
 		t.Errorf("projects.GetProjectByPurlName() error = did not get an error")
 	} else {
@@ -95,7 +95,7 @@ func TestProjectsSearch(t *testing.T) {
 	purlName = "NONEXISTENT"
 	mineId = -1
 	fmt.Printf("Searching for project list: %v - %v\n", purlName, purlType)
-	_, err = projectsModel.GetProjectByPurlName(purlName, mineId)
+	_, err = projectsModel.GetProjectByPurlName(ctx, purlName, mineId)
 	if err == nil {
 		t.Errorf("projects.GetProjectByPurlName() error = did not get an error")
 	} else {
@@ -115,15 +115,15 @@ func TestProjectsSearchBadSql(t *testing.T) {
 	db := testutils.SqliteSetup(t) // Setup SQL Lite DB
 	defer testutils.CloseDB(t, db)
 	q := database.NewDBSelectContext(s, db, nil, false)
-	projectsModel := NewProjectModel(ctx, s, q, db)
+	projectsModel := NewProjectModel(q, db)
 
-	_, err = projectsModel.GetProjectsByPurlName("rubbish", "rubbish")
+	_, err = projectsModel.GetProjectsByPurlName(ctx, "rubbish", "rubbish")
 	if err == nil {
 		t.Errorf("projects.GetProjectsByPurlName() error = did not get an error")
 	} else {
 		fmt.Printf("Got expected error = %v\n", err)
 	}
-	_, err = projectsModel.GetProjectByPurlName("rubbish", 2)
+	_, err = projectsModel.GetProjectByPurlName(ctx, "rubbish", 2)
 	if err == nil {
 		t.Errorf("projects.GetProjectByPurlName() error = did not get an error")
 	} else {

--- a/pkg/models/versions_test.go
+++ b/pkg/models/versions_test.go
@@ -40,11 +40,11 @@ func TestVersionsSearch(t *testing.T) {
 	testutils.LoadMockSQLData(t, db, "../../internal/testutils/mock")
 	q := database.NewDBSelectContext(s, db, nil, false)
 
-	versionModel := NewVersionModel(ctx, s, q, db)
+	versionModel := NewVersionModel(q, db)
 
 	var name = "1.0.0"
 	fmt.Printf("Searching for version: %v\n", name)
-	version, err := versionModel.GetVersionByName(name)
+	version, err := versionModel.GetVersionByName(ctx, name)
 	if err != nil {
 		t.Errorf("versions.GetVersionByName() error = %v", err)
 	}
@@ -55,7 +55,7 @@ func TestVersionsSearch(t *testing.T) {
 
 	name = ""
 	fmt.Printf("Searching for version: %v\n", name)
-	_, err = versionModel.GetVersionByName(name)
+	_, err = versionModel.GetVersionByName(ctx, name)
 	if err == nil {
 		t.Errorf("versions.GetVersionByName() error = did not get an error")
 	} else {
@@ -64,7 +64,7 @@ func TestVersionsSearch(t *testing.T) {
 
 	name = "22.22.22"
 	fmt.Printf("Searching for version: %v\n", name)
-	version, err = versionModel.GetVersionByName(name)
+	version, err = versionModel.GetVersionByName(ctx, name)
 	if err != nil {
 		t.Errorf("versions.GetVersionByName() error = %v", err)
 	}
@@ -87,8 +87,8 @@ func TestVersionsSearchBadSql(t *testing.T) {
 	defer testutils.CloseDB(t, db)
 	q := database.NewDBSelectContext(s, db, nil, false)
 
-	versionModel := NewVersionModel(ctx, s, q, db)
-	_, err = versionModel.GetVersionByName("rubbish")
+	versionModel := NewVersionModel(q, db)
+	_, err = versionModel.GetVersionByName(ctx, "rubbish")
 	if err == nil {
 		t.Errorf("versions.GetVersionByName() error = did not get an error")
 	} else {

--- a/pkg/scanoss/client.go
+++ b/pkg/scanoss/client.go
@@ -42,7 +42,7 @@ func New(ctx context.Context, s *zap.SugaredLogger, q *database.DBQueryContext, 
 	m := models.NewModels(ctx, s, q, db)
 
 	//Initialize services
-	component := services.NewComponentService(ctx, s, m)
+	component := services.NewComponentService(m)
 
 	return &Client{
 		ctx:       ctx,

--- a/pkg/scanoss/client.go
+++ b/pkg/scanoss/client.go
@@ -17,36 +17,30 @@
 package scanoss
 
 import (
-	"context"
 	"github.com/jmoiron/sqlx"
 
 	"github.com/scanoss/go-grpc-helper/pkg/grpc/database"
 	"github.com/scanoss/go-models/pkg/models"
 	"github.com/scanoss/go-models/pkg/services"
-	"go.uber.org/zap"
 )
 
 // Client provides a unified interface to SCANOSS data models and services.
 type Client struct {
-	ctx context.Context
-	s   *zap.SugaredLogger
-	q   *database.DBQueryContext
-	db  *sqlx.DB //TODO: remove db *sqlx.DB once QueryRowxContext is implemented on database.DBQueryContext and used across pkg/models
+	q  *database.DBQueryContext
+	db *sqlx.DB //TODO: remove db *sqlx.DB once QueryRowxContext is implemented on database.DBQueryContext and used across pkg/models
 
 	Models    *models.Models
 	Component *services.ComponentService
 }
 
 // New creates a SCANOSS Model Client.
-func New(ctx context.Context, s *zap.SugaredLogger, q *database.DBQueryContext, db *sqlx.DB) *Client {
-	m := models.NewModels(ctx, s, q, db)
+func New(q *database.DBQueryContext, db *sqlx.DB) *Client {
+	m := models.NewModels(q, db)
 
 	//Initialize services
 	component := services.NewComponentService(m)
 
 	return &Client{
-		ctx:       ctx,
-		s:         s,
 		Models:    m,
 		Component: component,
 	}

--- a/pkg/scanoss/client_test.go
+++ b/pkg/scanoss/client_test.go
@@ -42,7 +42,7 @@ func TestNew(t *testing.T) {
 
 	q := database.NewDBSelectContext(s, db, conn, false)
 
-	client := New(ctx, s, q, db)
+	client := New(q, db)
 
 	if client.Models == nil {
 		t.Error("New did not initialize Models")

--- a/pkg/services/component.go
+++ b/pkg/services/component.go
@@ -21,32 +21,28 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Masterminds/semver/v3"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/scanoss/go-models/pkg/models"
 	"github.com/scanoss/go-models/pkg/types"
 	purlutils "github.com/scanoss/go-purl-helper/pkg"
-	"go.uber.org/zap"
 	"sort"
 )
 
 // ComponentService orchestrates component lookup logic using extracted business logic.
 type ComponentService struct {
-	ctx    context.Context
-	s      *zap.SugaredLogger
 	models *models.Models
 }
 
 // NewComponentService creates a new ComponentService instance.
 // Uses the Models wrapper to access all necessary data access methods.
-func NewComponentService(ctx context.Context, s *zap.SugaredLogger, models *models.Models) *ComponentService {
+func NewComponentService(models *models.Models) *ComponentService {
 	return &ComponentService{
-		ctx:    ctx,
-		s:      s,
 		models: models,
 	}
 }
 
 // GetComponent retrieves component information based on PURL and requirements.
-func (cs *ComponentService) GetComponent(req types.ComponentRequest) (types.ComponentResponse, error) {
+func (cs *ComponentService) GetComponent(ctx context.Context, req types.ComponentRequest) (types.ComponentResponse, error) {
 	// TODO: Simplify component selection logic.
 	// The code was inspired from scanoss.com/dependencies and heavily refactored
 
@@ -77,16 +73,16 @@ func (cs *ComponentService) GetComponent(req types.ComponentRequest) (types.Comp
 
 	var allUrls []models.AllURL
 	if len(purl.Version) > 0 {
-		allUrls, err = cs.models.AllUrls.GetURLsByPurlNameTypeVersion(purlName, purl.Type, purl.Version)
+		allUrls, err = cs.models.AllUrls.GetURLsByPurlNameTypeVersion(ctx, purlName, purl.Type, purl.Version)
 	} else {
-		allUrls, err = cs.models.AllUrls.GetURLsByPurlNameType(purlName, purl.Type)
+		allUrls, err = cs.models.AllUrls.GetURLsByPurlNameType(ctx, purlName, purl.Type)
 	}
 
 	if err != nil {
 		return types.ComponentResponse{}, err
 	}
 
-	allUrl, err := cs.pickOneUrl(allUrls, purlName, purl.Type, purlReq)
+	allUrl, err := cs.pickOneUrl(ctx, allUrls, purlName, purl.Type, purlReq)
 	if err != nil {
 		return types.ComponentResponse{}, err
 	}
@@ -102,32 +98,34 @@ func (cs *ComponentService) GetComponent(req types.ComponentRequest) (types.Comp
 }
 
 // pickOneUrl takes the potential matching component/versions and selects the most appropriate one.
-func (cs *ComponentService) pickOneUrl(allUrls []models.AllURL, purlName, purlType, purlReq string) (models.AllURL, error) {
+func (cs *ComponentService) pickOneUrl(ctx context.Context, allUrls []models.AllURL, purlName, purlType, purlReq string) (models.AllURL, error) {
+	s := ctxzap.Extract(ctx).Sugar()
+
 	if len(allUrls) == 0 {
-		cs.s.Infof("No component match (in urls) found for %v, %v", purlName, purlType)
+		s.Infof("No component match (in urls) found for %v, %v", purlName, purlType)
 		return models.AllURL{}, nil
 	}
-	// cs.s.Debugf("Potential Matches: %v", allUrls)
+
 	var c *semver.Constraints
 	var urlMap = make(map[*semver.Version]models.AllURL)
 	if len(purlReq) > 0 {
-		cs.s.Debugf("Building version constraint for %v: %v", purlName, purlReq)
+		s.Debugf("Building version constraint for %v: %v", purlName, purlReq)
 		var err error
 		c, err = semver.NewConstraint(purlReq)
 		if err != nil {
-			cs.s.Warnf("Encountered an issue parsing version constraint string '%v' (%v,%v): %v", purlReq, purlName, purlType, err)
+			s.Warnf("Encountered an issue parsing version constraint string '%v' (%v,%v): %v", purlReq, purlName, purlType, err)
 		}
 	}
-	cs.s.Debugf("Checking versions...")
+	s.Debugf("Checking versions...")
 	for _, url := range allUrls {
 		if len(url.SemVer) > 0 || len(url.Version) > 0 {
 			v, err := semver.NewVersion(url.Version)
 			if err != nil && len(url.SemVer) > 0 {
-				cs.s.Debugf("Failed to parse SemVer: '%v'. Trying Version instead: %v (%v)", url.Version, url.SemVer, err)
+				s.Debugf("Failed to parse SemVer: '%v'. Trying Version instead: %v (%v)", url.Version, url.SemVer, err)
 				v, err = semver.NewVersion(url.SemVer) // Semver failed, try the normal version
 			}
 			if err != nil {
-				cs.s.Warnf("Encountered an issue parsing version string '%v' (%v) for %v: %v. Using v0.0.0", url.Version, url.SemVer, url, err)
+				s.Warnf("Encountered an issue parsing version string '%v' (%v) for %v: %v. Using v0.0.0", url.Version, url.SemVer, url, err)
 				v, err = semver.NewVersion("v0.0.0") // Semver failed, just use a standard version zero (for now)
 			}
 			if err == nil {
@@ -139,11 +137,11 @@ func (cs *ComponentService) pickOneUrl(allUrls []models.AllURL, purlName, purlTy
 				}
 			}
 		} else {
-			cs.s.Infof("Skipping match as it doesn't have a version: %#v", url)
+			s.Infof("Skipping match as it doesn't have a version: %#v", url)
 		}
 	}
 	if len(urlMap) == 0 { // TODO should we return the latest version anyway?
-		cs.s.Warnf("No component match found for %v, %v after filter %v", purlName, purlType, purlReq)
+		s.Warnf("No component match found for %v, %v after filter %v", purlName, purlType, purlReq)
 		return models.AllURL{}, nil
 	}
 	var versions = make([]*semver.Version, len(urlMap))
@@ -154,15 +152,15 @@ func (cs *ComponentService) pickOneUrl(allUrls []models.AllURL, purlName, purlTy
 	}
 	sort.Sort(semver.Collection(versions))
 	version := versions[len(versions)-1] // Get the latest (acceptable) URL version
-	cs.s.Debugf("Sorted versions: %v. Highest: %v", versions, version)
+	s.Debugf("Sorted versions: %v. Highest: %v", versions, version)
 
 	url, ok := urlMap[version] // Retrieve the latest accepted URL version
 	if !ok {
-		cs.s.Errorf("Problem retrieving URL data for %v (%v, %v)", version, purlName, purlType)
+		s.Errorf("Problem retrieving URL data for %v (%v, %v)", version, purlName, purlType)
 		return models.AllURL{}, fmt.Errorf("failed to retrieve specific URL version: %v", version)
 	}
 	url.URL, _ = purlutils.ProjectUrl(purlName, purlType)
 
-	cs.s.Debugf("Selected version: %#v", url)
+	s.Debugf("Selected version: %#v", url)
 	return url, nil // Return the best component match
 }

--- a/pkg/services/component_test.go
+++ b/pkg/services/component_test.go
@@ -42,7 +42,7 @@ func TestNewComponentService(t *testing.T) {
 	testutils.LoadMockSQLData(t, db, "../../internal/testutils/mock")
 
 	q := database.NewDBSelectContext(s, db, nil, false)
-	modelsDB := models.NewModels(ctx, s, q, db)
+	modelsDB := models.NewModels(q, db)
 
 	service := NewComponentService(modelsDB)
 
@@ -65,7 +65,7 @@ func TestGetComponentEmptyPurl(t *testing.T) {
 	testutils.LoadMockSQLData(t, db, "../../internal/testutils/mock")
 
 	q := database.NewDBSelectContext(s, db, nil, false)
-	modelsDB := models.NewModels(ctx, s, q, db)
+	modelsDB := models.NewModels(q, db)
 	service := NewComponentService(modelsDB)
 
 	req := types.ComponentRequest{
@@ -93,7 +93,7 @@ func TestGetComponentInvalidPurl(t *testing.T) {
 	testutils.LoadMockSQLData(t, db, "../../internal/testutils/mock")
 
 	q := database.NewDBSelectContext(s, db, nil, false)
-	modelsDB := models.NewModels(ctx, s, q, db)
+	modelsDB := models.NewModels(q, db)
 	service := NewComponentService(modelsDB)
 
 	req := types.ComponentRequest{
@@ -121,7 +121,7 @@ func TestGetComponentValidPurlButInvalidPurlName(t *testing.T) {
 	testutils.LoadMockSQLData(t, db, "../../internal/testutils/mock")
 
 	q := database.NewDBSelectContext(s, db, nil, false)
-	modelsDB := models.NewModels(ctx, s, q, db)
+	modelsDB := models.NewModels(q, db)
 	service := NewComponentService(modelsDB)
 
 	req := types.ComponentRequest{
@@ -149,7 +149,7 @@ func TestPickOneUrl(t *testing.T) {
 	testutils.LoadMockSQLData(t, db, "../../internal/testutils/mock")
 
 	q := database.NewDBSelectContext(s, db, nil, false)
-	modelsDB := models.NewModels(ctx, s, q, db)
+	modelsDB := models.NewModels(q, db)
 	service := NewComponentService(modelsDB)
 
 	tests := []struct {
@@ -280,7 +280,7 @@ func TestGetComponent(t *testing.T) {
 	testutils.LoadMockSQLData(t, db, "../../internal/testutils/mock")
 
 	q := database.NewDBSelectContext(s, db, nil, false)
-	modelsDB := models.NewModels(ctx, s, q, db)
+	modelsDB := models.NewModels(q, db)
 	service := NewComponentService(modelsDB)
 
 	tests := []struct {

--- a/pkg/services/component_test.go
+++ b/pkg/services/component_test.go
@@ -44,7 +44,7 @@ func TestNewComponentService(t *testing.T) {
 	q := database.NewDBSelectContext(s, db, nil, false)
 	modelsDB := models.NewModels(ctx, s, q, db)
 
-	service := NewComponentService(ctx, s, modelsDB)
+	service := NewComponentService(modelsDB)
 
 	if service == nil {
 		t.Fatal("NewComponentService returned nil")
@@ -66,14 +66,14 @@ func TestGetComponentEmptyPurl(t *testing.T) {
 
 	q := database.NewDBSelectContext(s, db, nil, false)
 	modelsDB := models.NewModels(ctx, s, q, db)
-	service := NewComponentService(ctx, s, modelsDB)
+	service := NewComponentService(modelsDB)
 
 	req := types.ComponentRequest{
 		Purl:        "",
 		Requirement: "",
 	}
 
-	_, err = service.GetComponent(req)
+	_, err = service.GetComponent(ctx, req)
 	if err == nil {
 		t.Error("GetComponent should return error for empty purl")
 	}
@@ -94,14 +94,14 @@ func TestGetComponentInvalidPurl(t *testing.T) {
 
 	q := database.NewDBSelectContext(s, db, nil, false)
 	modelsDB := models.NewModels(ctx, s, q, db)
-	service := NewComponentService(ctx, s, modelsDB)
+	service := NewComponentService(modelsDB)
 
 	req := types.ComponentRequest{
 		Purl:        "invalid-purl",
 		Requirement: "",
 	}
 
-	_, err = service.GetComponent(req)
+	_, err = service.GetComponent(ctx, req)
 	if err == nil {
 		t.Error("GetComponent should return error for invalid purl")
 	}
@@ -122,14 +122,14 @@ func TestGetComponentValidPurlButInvalidPurlName(t *testing.T) {
 
 	q := database.NewDBSelectContext(s, db, nil, false)
 	modelsDB := models.NewModels(ctx, s, q, db)
-	service := NewComponentService(ctx, s, modelsDB)
+	service := NewComponentService(modelsDB)
 
 	req := types.ComponentRequest{
 		Purl:        "pkg:npm/",
 		Requirement: "",
 	}
 
-	_, err = service.GetComponent(req)
+	_, err = service.GetComponent(ctx, req)
 	if err == nil {
 		t.Error("GetComponent should return error for purl with empty name")
 	}
@@ -150,7 +150,7 @@ func TestPickOneUrl(t *testing.T) {
 
 	q := database.NewDBSelectContext(s, db, nil, false)
 	modelsDB := models.NewModels(ctx, s, q, db)
-	service := NewComponentService(ctx, s, modelsDB)
+	service := NewComponentService(modelsDB)
 
 	tests := []struct {
 		name          string
@@ -244,7 +244,7 @@ func TestPickOneUrl(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := service.pickOneUrl(tt.urls, tt.component, tt.purlType, tt.requirement)
+			result, err := service.pickOneUrl(ctx, tt.urls, tt.component, tt.purlType, tt.requirement)
 
 			if tt.shouldError && err == nil {
 				t.Error("expected error but got none")
@@ -281,7 +281,7 @@ func TestGetComponent(t *testing.T) {
 
 	q := database.NewDBSelectContext(s, db, nil, false)
 	modelsDB := models.NewModels(ctx, s, q, db)
-	service := NewComponentService(ctx, s, modelsDB)
+	service := NewComponentService(modelsDB)
 
 	tests := []struct {
 		name        string
@@ -399,7 +399,7 @@ func TestGetComponent(t *testing.T) {
 				Requirement: tt.requirement,
 			}
 
-			result, err := service.GetComponent(req)
+			result, err := service.GetComponent(ctx, req)
 
 			if tt.shouldError {
 				if err == nil {


### PR DESCRIPTION
### Description

This pull request simplifies multiple model constructors by removing the `logger` and `ctx` parameters. The related methods are updated to accept `ctx` as a parameter where needed. Changes include updates to the following models:

- `VersionModel`
- `ProjectModel`
- `LicenseModel`
- `AllUrlsModel`

