### PR TITLE
feat(db-version): add DBVersion model with table existence check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,42 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Upcoming changes...
+
+## [0.4.0] - 2026-01-30
+### Added
+- Added `DBVersionModel` to query the `db_version` table for schema version, package name, release, and creation date
+- Added `ErrTableNotFound` sentinel error and `tableExists` helper for backward compatibility with databases that predate certain tables
 
 ## [0.3.0] - 2026-01-29
-
 ### Changed
 - `GetComponent` now bypasses version resolution when the requirement is a fixed version (no range operators)
   - Returns directly without database lookup for exact versions
   - Covers operators from npm (`^~<>=*|`), pip (`~=!<>=`), maven/nuget (`[](),`), cargo, composer, and gems
 
-[Unreleased]: https://github.com/scanoss/go-models/compare/v0.3.0...HEAD
-[0.3.0]: https://github.com/scanoss/go-models/releases/tag/v0.3.0
+## [0.2.0] - 2025-08-08
+### Changed
+- Refactored model constructors to use `*sqlx.DB` instead of `DBQueryContext`, removing `go-grpc-helper` dependency
+- Simplified model constructors by removing logger and context parameters
+- Renamed `LicenseID` field to `SPDX` in License model
+
+## [0.1.1] - 2025-07-24
+### Fixed
+- Use `LicenseID` as ID from the DB
+
+## [0.1.0] - 2025-07-24
+### Added
+- Initial release with shared models for SCANOSS services
+- Added `AllUrlsModel` for URL lookups
+- Added `ProjectModel` for project data access
+- Added `VersionModel` for version data access
+- Added `LicenseModel` for license data access
+- Added `MineModel` for mine data access
+- Added unified `Models` struct for accessing all models
+
+[0.1.0]: https://github.com/scanoss/go-models/compare/v0.0.1...v0.1.0
+[0.1.1]: https://github.com/scanoss/go-models/compare/v0.1.0...v0.1.1
+[0.2.0]: https://github.com/scanoss/go-models/compare/v0.1.1...v0.2.0
+[0.3.0]: https://github.com/scanoss/go-models/compare/v0.2.0...v0.3.0
+[0.4.0]: https://github.com/scanoss/go-models/compare/v0.3.0...v0.4.0

--- a/internal/testutils/mock/db_version.sql
+++ b/internal/testutils/mock/db_version.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS db_version;
+CREATE TABLE db_version
+(
+    package_name   text not null,
+    schema_version text not null,
+    created_at     text not null,
+    db_release     text not null
+);
+
+INSERT INTO db_version (package_name, schema_version, created_at, db_release)
+VALUES ('base', '1.0.0', '2026-01-15T10:30:00Z', '2026.01');

--- a/pkg/models/db_version.go
+++ b/pkg/models/db_version.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (C) 2026 SCANOSS.COM
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Handle all interaction with the db_version table
+
+package models
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"github.com/jmoiron/sqlx"
+)
+
+// DBVersionModel provides database access for the db_version table.
+type DBVersionModel struct {
+	db *sqlx.DB
+}
+
+// DBVersion represents the database version information from the db_version table.
+type DBVersion struct {
+	PackageName   string `db:"package_name"`
+	SchemaVersion string `db:"schema_version"`
+	CreatedAt     string `db:"created_at"`
+	DBRelease     string `db:"db_release"`
+}
+
+// NewDBVersionModel creates a new instance of the DBVersion Model.
+func NewDBVersionModel(db *sqlx.DB) *DBVersionModel {
+	return &DBVersionModel{db: db}
+}
+
+// GetCurrentVersion retrieves the current database schema version.
+// Returns ErrTableNotFound if the db_version table does not exist.
+// This check supports backward compatibility with databases that predate the db_version table.
+func (m *DBVersionModel) GetCurrentVersion(ctx context.Context) (DBVersion, error) {
+	s := ctxzap.Extract(ctx).Sugar()
+	if !tableExists(ctx, m.db, "db_version") {
+		s.Debug("db_version table does not exist")
+		return DBVersion{}, ErrTableNotFound
+	}
+	var dbVersion DBVersion
+	err := m.db.QueryRowxContext(ctx,
+		"SELECT package_name, schema_version, created_at, db_release FROM db_version LIMIT 1").StructScan(&dbVersion)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			s.Debug("No version found in db_version table")
+			return DBVersion{}, nil
+		}
+		return DBVersion{}, fmt.Errorf("failed to query db_version table: %w", err)
+	}
+	if t, err := time.Parse(time.RFC3339, dbVersion.CreatedAt); err == nil {
+		dbVersion.CreatedAt = t.Format(time.DateOnly)
+	}
+	return dbVersion, nil
+}

--- a/pkg/models/db_version_test.go
+++ b/pkg/models/db_version_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (C) 2018-2025 SCANOSS.COM
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package models
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"github.com/scanoss/go-models/internal/testutils"
+	zlog "github.com/scanoss/zap-logging-helper/pkg/logger"
+)
+
+func TestDBVersionGetCurrentVersion(t *testing.T) {
+	err := zlog.NewSugaredDevLogger()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a sugared logger", err)
+	}
+	defer zlog.SyncZap()
+	ctx := ctxzap.ToContext(context.Background(), zlog.L)
+	db := testutils.SqliteSetup(t)
+	defer testutils.CloseDB(t, db)
+	testutils.LoadSQLDataFile(t, db, "../../internal/testutils/mock/db_version.sql")
+
+	model := NewDBVersionModel(db)
+
+	fmt.Println("Testing GetCurrentVersion with data...")
+	version, err := model.GetCurrentVersion(ctx)
+	if err != nil {
+		t.Errorf("DBVersionModel.GetCurrentVersion() error = %v", err)
+	}
+	if len(version.SchemaVersion) == 0 {
+		t.Errorf("DBVersionModel.GetCurrentVersion() returned empty schema version")
+	}
+	if version.SchemaVersion != "1.0.0" {
+		t.Errorf("DBVersionModel.GetCurrentVersion() schema_version = %v, want 1.0.0", version.SchemaVersion)
+	}
+	if version.PackageName != "base" {
+		t.Errorf("DBVersionModel.GetCurrentVersion() package_name = %v, want components", version.PackageName)
+	}
+	if version.DBRelease != "2026.01" {
+		t.Errorf("DBVersionModel.GetCurrentVersion() db_release = %v, want 2026.01", version.DBRelease)
+	}
+	if version.CreatedAt != "2026-01-15" {
+		t.Errorf("DBVersionModel.GetCurrentVersion() created_at = %v, want 2026-01-15", version.CreatedAt)
+	}
+	fmt.Printf("DBVersion: %#v\n", version)
+}
+
+// TestDBVersionGetCurrentVersionNoTable tests querying when the db_version table doesn't exist.
+func TestDBVersionGetCurrentVersionNoTable(t *testing.T) {
+	err := zlog.NewSugaredDevLogger()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a sugared logger", err)
+	}
+	defer zlog.SyncZap()
+	ctx := ctxzap.ToContext(context.Background(), zlog.L)
+	db := testutils.SqliteSetup(t)
+	defer testutils.CloseDB(t, db)
+
+	model := NewDBVersionModel(db)
+
+	fmt.Println("Testing GetCurrentVersion without table...")
+	version, err := model.GetCurrentVersion(ctx)
+	if !errors.Is(err, ErrTableNotFound) {
+		t.Errorf("DBVersionModel.GetCurrentVersion() expected ErrTableNotFound, got %v", err)
+	}
+	if len(version.SchemaVersion) > 0 {
+		t.Errorf("DBVersionModel.GetCurrentVersion() expected empty version for missing table, got %v", version.SchemaVersion)
+	}
+	fmt.Printf("DBVersion (empty expected): %#v\n", version)
+}
+
+// TestDBVersionGetCurrentVersionEmptyTable tests querying when the db_version table exists but is empty.
+func TestDBVersionGetCurrentVersionEmptyTable(t *testing.T) {
+	err := zlog.NewSugaredDevLogger()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a sugared logger", err)
+	}
+	defer zlog.SyncZap()
+	ctx := ctxzap.ToContext(context.Background(), zlog.L)
+	db := testutils.SqliteSetup(t)
+	defer testutils.CloseDB(t, db)
+	// Create the table but don't insert any data
+	testutils.LoadSQLDataFile(t, db, "../../internal/testutils/mock/db_version.sql")
+	_, delErr := db.Exec("DELETE FROM db_version")
+	if delErr != nil {
+		t.Fatalf("failed to clear db_version table: %v", delErr)
+	}
+
+	model := NewDBVersionModel(db)
+
+	fmt.Println("Testing GetCurrentVersion with empty table...")
+	version, err := model.GetCurrentVersion(ctx)
+	if err != nil {
+		t.Errorf("DBVersionModel.GetCurrentVersion() error = %v, expected nil for empty table", err)
+	}
+	if len(version.SchemaVersion) > 0 {
+		t.Errorf("DBVersionModel.GetCurrentVersion() expected empty version for empty table, got %v", version.SchemaVersion)
+	}
+	fmt.Printf("DBVersion (empty expected): %#v\n", version)
+}

--- a/pkg/models/errors.go
+++ b/pkg/models/errors.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Copyright (C) 2026 SCANOSS.COM
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package models
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// ErrTableNotFound is returned when a required database table does not exist.
+var ErrTableNotFound = errors.New("table not found")
+
+// tableExists checks if a table exists in an SQLite database.
+// This is used for backward compatibility with databases that predate certain tables.
+func tableExists(ctx context.Context, db *sqlx.DB, tableName string) bool {
+	var exists bool
+	err := db.QueryRowContext(ctx,
+		"SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name=?)",
+		tableName).Scan(&exists)
+	return err == nil && exists
+}

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -23,22 +23,24 @@ import (
 // Models provides unified access to all SCANOSS data models.
 // It maintains database connections and provides access to individual model instances.
 type Models struct {
-	AllUrls  *AllUrlsModel
-	Projects *ProjectModel
-	Versions *VersionModel
-	Licenses *LicenseModel
-	Mines    *MineModel
+	AllUrls   *AllUrlsModel
+	Projects  *ProjectModel
+	Versions  *VersionModel
+	Licenses  *LicenseModel
+	Mines     *MineModel
+	DBVersion *DBVersionModel
 }
 
 // NewModels creates a new instance of the unified SCANOSS models database wrapper.
 // It initializes all individual models and sets up their dependencies.
 func NewModels(db *sqlx.DB) *Models {
 	models := &Models{
-		AllUrls:  NewAllURLModel(db),
-		Projects: NewProjectModel(db),
-		Versions: NewVersionModel(db),
-		Licenses: NewLicenseModel(db),
-		Mines:    NewMineModel(db),
+		AllUrls:   NewAllURLModel(db),
+		Projects:  NewProjectModel(db),
+		Versions:  NewVersionModel(db),
+		Licenses:  NewLicenseModel(db),
+		Mines:     NewMineModel(db),
+		DBVersion: NewDBVersionModel(db),
 	}
 
 	return models

--- a/pkg/models/models_test.go
+++ b/pkg/models/models_test.go
@@ -55,4 +55,8 @@ func TestNewDB(t *testing.T) {
 	if models.Mines == nil {
 		t.Error("NewModels did not initialize Mines model")
 	}
+
+	if models.DBVersion == nil {
+		t.Error("NewModels did not initialize DBVersion model")
+	}
 }


### PR DESCRIPTION

  - Add DBVersionModel to query the db_version table for schema version, package name, release, and creation date
 - Handle databases that don't have the db_version table by checking sqlite_master before querying, returning ErrTableNotFound sentinel error  
 - Truncate created_at to date-only resolution (time.DateOnly) since time precision is not needed
 - Add shared errors.go with ErrTableNotFound and tableExists helper


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database version tracking to monitor schema versions and release information.

* **Tests**
  * Added comprehensive test coverage for version retrieval, including scenarios for missing tables and empty data states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->