### PR TITLE
chore(component):SP-4219 add GetComponentVersions method to list all …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-03-31
+### Added
+- Added `GetComponentVersions` method in `ComponentService` to retrieve all available versions for a given PURL
+- Added `GetVersionsByPurlNameType` method in `AllUrlsModel` to query distinct versions by PURL name and type
+- Added `ComponentVersionsResponse` type for version listing responses
+- Added `TestGetComponentVersions` test cases
+
 ## [0.7.0] - 2026-03-16
 ### Changed
 - Changed `CheckPurl` to unexported `checkPurl` in `ComponentService`
@@ -86,3 +93,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.5.1]: https://github.com/scanoss/go-models/compare/v0.5.0...v0.5.1
 [0.6.0]: https://github.com/scanoss/go-models/compare/v0.5.1...v0.6.0
 [0.7.0]: https://github.com/scanoss/go-models/compare/v0.6.0...v0.7.0
+[0.8.0]: https://github.com/scanoss/go-models/compare/v0.7.0...v0.8.0

--- a/pkg/models/all_urls.go
+++ b/pkg/models/all_urls.go
@@ -33,15 +33,16 @@ type AllUrlsModel struct {
 
 // AllURL represents a row on the AllURL table.
 type AllURL struct {
-	Component string `db:"component"`
-	Version   string `db:"version"`
-	SemVer    string `db:"semver"`
-	License   string `db:"license"`
-	LicenseID int32  `db:"license_id"`
-	IsSpdx    bool   `db:"is_spdx"`
-	PurlName  string `db:"purl_name"`
-	MineID    int32  `db:"mine_id"`
-	URL       string `db:"-"` // Computed field, not from database
+	Component string  `db:"component"`
+	Version   string  `db:"version"`
+	SemVer    string  `db:"semver"`
+	License   string  `db:"license"`
+	LicenseID int32   `db:"license_id"`
+	IsSpdx    bool    `db:"is_spdx"`
+	PurlName  string  `db:"purl_name"`
+	MineID    int32   `db:"mine_id"`
+	Date      *string `db:"date"`
+	URL       string  `db:"-"` // Computed field, not from database
 }
 
 // NewAllURLModel creates a new instance of the AllUrlsModel.
@@ -118,6 +119,37 @@ func (m *AllUrlsModel) GetURLsByPurlNameTypeVersion(ctx context.Context, purlNam
 	}
 
 	s.Debugf("Found %v results for %v, %v, %v.", len(allUrls), purlType, purlName, purlVersion)
+	return allUrls, nil
+}
+
+// GetVersionsByPurlNameType retrieves all distinct versions for a given PURL name and type.
+func (m *AllUrlsModel) GetVersionsByPurlNameType(ctx context.Context, purlName, purlType string) ([]AllURL, error) {
+	s := ctxzap.Extract(ctx).Sugar()
+	if len(purlName) == 0 {
+		s.Error("Please specify a valid Purl Name to query")
+		return nil, errors.New("please specify a valid Purl Name to query")
+	}
+	if len(purlType) == 0 {
+		s.Errorf("Please specify a valid Purl Type to query: %v", purlName)
+		return nil, errors.New("please specify a valid Purl Type to query")
+	}
+
+	query := "SELECT DISTINCT component, v.version_name AS version, v.semver AS semver," +
+		" l.license_name AS license, l.is_spdx AS is_spdx, u.license_id," +
+		" purl_name, mine_id, date FROM all_urls u" +
+		" LEFT JOIN mines m ON u.mine_id = m.id" +
+		" LEFT JOIN licenses l ON u.license_id = l.id" +
+		" LEFT JOIN versions v ON u.version_id = v.id" +
+		" WHERE m.purl_type = $1 AND u.purl_name = $2 ORDER BY date DESC"
+
+	var allUrls []AllURL
+	err := m.db.SelectContext(ctx, &allUrls, query, purlType, purlName)
+	if err != nil {
+		s.Errorf("Failed to query all urls table for %v - %v: %v", purlType, purlName, err)
+		return nil, fmt.Errorf("failed to query the all urls table: %v", err)
+	}
+
+	s.Debugf("Found %v distinct versions for %v, %v.", len(allUrls), purlType, purlName)
 	return allUrls, nil
 }
 

--- a/pkg/services/component.go
+++ b/pkg/services/component.go
@@ -135,6 +135,42 @@ func (cs *ComponentService) GetComponent(ctx context.Context, req types.Componen
 	}, nil
 }
 
+// GetComponentVersions retrieves all available versions for a given PURL.
+func (cs *ComponentService) GetComponentVersions(ctx context.Context, purl string) (types.ComponentVersionsResponse, error) {
+	packageURL, err := purlutils.PurlFromString(purl)
+	if err != nil {
+		return types.ComponentVersionsResponse{}, fmt.Errorf("failed to parse purl: %w", err)
+	}
+
+	purlName, err := purlutils.PurlNameFromString(purl)
+	if err != nil {
+		return types.ComponentVersionsResponse{}, fmt.Errorf("failed to extract purl name: %w", err)
+	}
+
+	allUrls, err := cs.models.AllUrls.GetVersionsByPurlNameType(ctx, purlName, packageURL.Type)
+	if err != nil {
+		return types.ComponentVersionsResponse{}, err
+	}
+
+	seen := make(map[string]struct{})
+	var versions []string
+	for _, u := range allUrls {
+		if len(u.Version) == 0 {
+			continue
+		}
+		if _, ok := seen[u.Version]; ok {
+			continue
+		}
+		seen[u.Version] = struct{}{}
+		versions = append(versions, u.Version)
+	}
+
+	return types.ComponentVersionsResponse{
+		Purl:     purl,
+		Versions: versions,
+	}, nil
+}
+
 // pickOneUrl takes the potential matching component/versions and selects the most appropriate one.
 
 func (cs *ComponentService) pickOneUrl(ctx context.Context, allUrls []models.AllURL, purlName, purlType, purlReq string) (models.AllURL, error) {

--- a/pkg/services/component_test.go
+++ b/pkg/services/component_test.go
@@ -408,6 +408,95 @@ func TestGetComponent(t *testing.T) {
 	}
 }
 
+func TestGetComponentVersionsInvalidPurl(t *testing.T) {
+	err := zlog.NewSugaredDevLogger()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a sugared logger", err)
+	}
+	defer zlog.SyncZap()
+	ctx := ctxzap.ToContext(context.Background(), zlog.L)
+	db := testutils.SqliteSetup(t)
+	defer testutils.CloseDB(t, db)
+
+	testutils.LoadMockSQLData(t, db, "../../internal/testutils/mock")
+
+	modelsDB := models.NewModels(db)
+	service := NewComponentService(modelsDB)
+
+	invalidPurls := []string{"invalid-purl", "pkg:npm/"}
+	for _, purl := range invalidPurls {
+		_, getErr := service.GetComponentVersions(ctx, purl)
+		if getErr == nil {
+			t.Errorf("expected error for purl %q but got none", purl)
+		}
+	}
+}
+
+func TestGetComponentVersionsNonExistent(t *testing.T) {
+	err := zlog.NewSugaredDevLogger()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a sugared logger", err)
+	}
+	defer zlog.SyncZap()
+	ctx := ctxzap.ToContext(context.Background(), zlog.L)
+	db := testutils.SqliteSetup(t)
+	defer testutils.CloseDB(t, db)
+
+	testutils.LoadMockSQLData(t, db, "../../internal/testutils/mock")
+
+	modelsDB := models.NewModels(db)
+	service := NewComponentService(modelsDB)
+
+	result, getErr := service.GetComponentVersions(ctx, "pkg:npm/non-existent-package")
+	if getErr != nil {
+		t.Errorf("unexpected error: %v", getErr)
+	}
+	if len(result.Versions) != 0 {
+		t.Errorf("expected empty versions, got %d", len(result.Versions))
+	}
+}
+
+func TestGetComponentVersions(t *testing.T) {
+	err := zlog.NewSugaredDevLogger()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a sugared logger", err)
+	}
+	defer zlog.SyncZap()
+	ctx := ctxzap.ToContext(context.Background(), zlog.L)
+	db := testutils.SqliteSetup(t)
+	defer testutils.CloseDB(t, db)
+
+	testutils.LoadMockSQLData(t, db, "../../internal/testutils/mock")
+
+	modelsDB := models.NewModels(db)
+	service := NewComponentService(modelsDB)
+
+	purl := "pkg:npm/electron-updater"
+	expectedVersions := []string{"4.0.8", "4.6.5", "4.3.5", "4.2.0"}
+
+	result, getErr := service.GetComponentVersions(ctx, purl)
+	if getErr != nil {
+		t.Fatalf("unexpected error: %v", getErr)
+	}
+	if result.Purl != purl {
+		t.Errorf("expected purl %s, got %s", purl, result.Purl)
+	}
+	// Check no duplicates
+	seen := make(map[string]struct{})
+	for _, v := range result.Versions {
+		if _, ok := seen[v]; ok {
+			t.Errorf("duplicate version found: %s", v)
+		}
+		seen[v] = struct{}{}
+	}
+	// Check all expected versions are present
+	for _, expected := range expectedVersions {
+		if _, ok := seen[expected]; !ok {
+			t.Errorf("expected version %s not found in results", expected)
+		}
+	}
+}
+
 func TestCheckPurl(t *testing.T) {
 	err := zlog.NewSugaredDevLogger()
 	if err != nil {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -42,3 +42,12 @@ type ComponentResponse struct {
 	// Version is the component version.
 	Version string `json:"version"`
 }
+
+// ComponentVersionsResponse represents the response containing all versions for a component.
+type ComponentVersionsResponse struct {
+	// Purl is the Package URL of the component (without version)
+	Purl string `json:"purl"`
+
+	// Versions is the list of all available versions for the component.
+	Versions []string `json:"versions"`
+}


### PR DESCRIPTION
…versions for a PURL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API response to retrieve available component versions by package URL (PURL); responses include the queried PURL and a deduplicated, date-ordered list of versions.
* **Tests**
  * New unit tests for invalid PURLs, non-existent components, and successful version lookup.
* **Documentation**
  * Changelog updated with a 0.8.0 release entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->